### PR TITLE
Add GitHub Actions for automated Cloudflare Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy to Cloudflare Pages
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    name: Deploy to Cloudflare Pages
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy out --project-name=tornado-alley

--- a/README.md
+++ b/README.md
@@ -50,7 +50,27 @@ This creates an optimized production build in the `out/` directory.
 
 ## Deployment to Cloudflare Pages
 
-### Option 1: Via Cloudflare Dashboard (Recommended)
+### Automated Deployment (GitHub Actions)
+
+This repository includes a GitHub Actions workflow that automatically deploys to Cloudflare Pages on every push to the `main` branch.
+
+#### Setup Required Secrets
+
+To enable automated deployments, add the following secrets to your GitHub repository:
+
+1. Go to your repository Settings > Secrets and variables > Actions
+2. Add the following secrets:
+   - **CLOUDFLARE_API_TOKEN**: Your Cloudflare API token
+     - Create at: Cloudflare Dashboard > My Profile > API Tokens
+     - Use the "Edit Cloudflare Pages" template or create a custom token with "Cloudflare Pages:Edit" permissions
+   - **CLOUDFLARE_ACCOUNT_ID**: Your Cloudflare Account ID
+     - Found at: Cloudflare Dashboard > Workers & Pages > Overview (right sidebar)
+
+Once configured, every push to `main` will automatically build and deploy your site.
+
+### Manual Deployment Options
+
+#### Option 1: Via Cloudflare Dashboard
 
 1. Push your code to GitHub/GitLab
 2. Go to [Cloudflare Dashboard](https://dash.cloudflare.com)
@@ -62,7 +82,7 @@ This creates an optimized production build in the `out/` directory.
    - **Node version**: 20.9.0 or higher
 6. Deploy
 
-### Option 2: Via Wrangler CLI
+#### Option 2: Via Wrangler CLI
 
 1. Install Wrangler:
 


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow for automated deployment to Cloudflare Pages on push to `main`
- Updates README with comprehensive deployment documentation including automated and manual options
- Provides clear instructions for setting up required GitHub secrets

## Changes Made
- Created `.github/workflows/deploy.yml` with Cloudflare Pages deployment workflow
- Updated README with automated deployment section and reorganized manual deployment options
- Workflow triggers on push to main and on pull requests for testing

## Setup Required
After merging, configure these GitHub repository secrets:
- `CLOUDFLARE_API_TOKEN` - API token with Cloudflare Pages edit permissions
- `CLOUDFLARE_ACCOUNT_ID` - Your Cloudflare account ID

## Test Plan
- [x] Workflow file created with proper syntax
- [x] README updated with clear instructions
- [ ] Test deployment after secrets are configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)