### PR TITLE
Modernize homepage with full-screen hero design

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -22,10 +22,9 @@ export default function Home() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
-      <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-slate-900 via-blue-900 to-slate-900">
-        <main className="flex flex-col items-center justify-center gap-8 px-6 py-12 text-center">
-        {/* Main Image */}
-        <div className="relative h-64 w-64 overflow-hidden rounded-lg shadow-2xl">
+      <div className="relative min-h-screen w-full bg-black">
+        {/* Full-width Hero Image Section */}
+        <div className="relative w-full h-screen">
           <Image
             src="https://pub-c59a7d8d850842288d7852af88d4ee66.r2.dev/images/2025_12_31_ground_zero.jpg"
             alt="Tornado Alley Ground Zero"
@@ -33,97 +32,100 @@ export default function Home() {
             className="object-cover"
             priority
           />
+          {/* Gradient Overlay for better text readability */}
+          <div className="absolute inset-0 bg-gradient-to-b from-black/60 via-black/40 to-black"></div>
+
+          {/* Content Overlay */}
+          <div className="absolute inset-0 flex flex-col items-center justify-center px-6 text-center">
+            <h1 className="text-6xl font-bold text-white md:text-7xl lg:text-8xl xl:text-9xl mb-8 drop-shadow-2xl">
+              Welcome to Tornado Alley
+            </h1>
+
+            {/* Social Media Links */}
+            <div className="flex flex-wrap items-center justify-center gap-4 md:gap-6 mt-8">
+              <a
+                href="https://www.facebook.com/f3tornadoalley"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center justify-center gap-2 rounded-full bg-blue-600 w-40 h-12 text-white transition-all hover:bg-blue-700 hover:scale-105 shadow-xl backdrop-blur-sm"
+                aria-label="Visit our Facebook page"
+              >
+                <svg
+                  className="h-5 w-5"
+                  fill="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M22 12c0-5.523-4.477-10-10-10S2 6.477 2 12c0 4.991 3.657 9.128 8.438 9.878v-6.987h-2.54V12h2.54V9.797c0-2.506 1.492-3.89 3.777-3.89 1.094 0 2.238.195 2.238.195v2.46h-1.26c-1.243 0-1.63.771-1.63 1.562V12h2.773l-.443 2.89h-2.33v6.988C18.343 21.128 22 16.991 22 12z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+                <span className="font-medium">Facebook</span>
+              </a>
+
+              <a
+                href="https://www.instagram.com/f3tornadoalley/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center justify-center gap-2 rounded-full bg-gradient-to-r from-purple-600 to-pink-600 w-40 h-12 text-white transition-all hover:from-purple-700 hover:to-pink-700 hover:scale-105 shadow-xl backdrop-blur-sm"
+                aria-label="Visit our Instagram page"
+              >
+                <svg
+                  className="h-5 w-5"
+                  fill="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M12.315 2c2.43 0 2.784.013 3.808.06 1.064.049 1.791.218 2.427.465a4.902 4.902 0 011.772 1.153 4.902 4.902 0 011.153 1.772c.247.636.416 1.363.465 2.427.048 1.067.06 1.407.06 4.123v.08c0 2.643-.012 2.987-.06 4.043-.049 1.064-.218 1.791-.465 2.427a4.902 4.902 0 01-1.153 1.772 4.902 4.902 0 01-1.772 1.153c-.636.247-1.363.416-2.427.465-1.067.048-1.407.06-4.123.06h-.08c-2.643 0-2.987-.012-4.043-.06-1.064-.049-1.791-.218-2.427-.465a4.902 4.902 0 01-1.772-1.153 4.902 4.902 0 01-1.153-1.772c-.247-.636-.416-1.363-.465-2.427-.047-1.024-.06-1.379-.06-3.808v-.63c0-2.43.013-2.784.06-3.808.049-1.064.218-1.791.465-2.427a4.902 4.902 0 011.153-1.772A4.902 4.902 0 015.45 2.525c.636-.247 1.363-.416 2.427-.465C8.901 2.013 9.256 2 11.685 2h.63zm-.081 1.802h-.468c-2.456 0-2.784.011-3.807.058-.975.045-1.504.207-1.857.344-.467.182-.8.398-1.15.748-.35.35-.566.683-.748 1.15-.137.353-.3.882-.344 1.857-.047 1.023-.058 1.351-.058 3.807v.468c0 2.456.011 2.784.058 3.807.045.975.207 1.504.344 1.857.182.466.399.8.748 1.15.35.35.683.566 1.15.748.353.137.882.3 1.857.344 1.054.048 1.37.058 4.041.058h.08c2.597 0 2.917-.01 3.96-.058.976-.045 1.505-.207 1.858-.344.466-.182.8-.398 1.15-.748.35-.35.566-.683.748-1.15.137-.353.3-.882.344-1.857.048-1.055.058-1.37.058-4.041v-.08c0-2.597-.01-2.917-.058-3.96-.045-.976-.207-1.505-.344-1.858a3.097 3.097 0 00-.748-1.15 3.098 3.098 0 00-1.15-.748c-.353-.137-.882-.3-1.857-.344-1.023-.047-1.351-.058-3.807-.058zM12 6.865a5.135 5.135 0 110 10.27 5.135 5.135 0 010-10.27zm0 1.802a3.333 3.333 0 100 6.666 3.333 3.333 0 000-6.666zm5.338-3.205a1.2 1.2 0 110 2.4 1.2 1.2 0 010-2.4z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+                <span className="font-medium">Instagram</span>
+              </a>
+
+              <a
+                href="https://x.com/f3tornadoalley"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center justify-center gap-2 rounded-full bg-white/10 backdrop-blur-sm w-40 h-12 text-white transition-all hover:bg-white/20 hover:scale-105 shadow-xl border border-white/20"
+                aria-label="Visit our X (Twitter) page"
+              >
+                <svg
+                  className="h-5 w-5"
+                  fill="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+                </svg>
+                <span className="font-medium">X</span>
+              </a>
+
+              <a
+                href="https://www.tiktok.com/@f3tornadoalley"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center justify-center gap-2 rounded-full bg-white/10 backdrop-blur-sm w-40 h-12 text-white transition-all hover:bg-white/20 hover:scale-105 shadow-xl border border-white/20"
+                aria-label="Visit our TikTok page"
+              >
+                <svg
+                  className="h-5 w-5"
+                  fill="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path d="M19.59 6.69a4.83 4.83 0 0 1-3.77-4.25V2h-3.45v13.67a2.89 2.89 0 0 1-5.2 1.74 2.89 2.89 0 0 1 2.31-4.64 2.93 2.93 0 0 1 .88.13V9.4a6.84 6.84 0 0 0-1-.05A6.33 6.33 0 0 0 5 20.1a6.34 6.34 0 0 0 10.86-4.43v-7a8.16 8.16 0 0 0 4.77 1.52v-3.4a4.85 4.85 0 0 1-1-.1z" />
+                </svg>
+                <span className="font-medium">TikTok</span>
+              </a>
+            </div>
+          </div>
         </div>
-
-        {/* Main Heading */}
-        <h1 className="text-5xl font-bold text-white md:text-6xl lg:text-7xl">
-          Welcome to Tornado Alley
-        </h1>
-
-        {/* Social Media Links */}
-        <div className="flex flex-wrap items-center justify-center gap-6 mt-8">
-          <a
-            href="https://www.facebook.com/f3tornadoalley"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-2 rounded-full bg-blue-600 px-6 py-3 text-white transition-all hover:bg-blue-700 hover:scale-105"
-            aria-label="Visit our Facebook page"
-          >
-            <svg
-              className="h-5 w-5"
-              fill="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path
-                fillRule="evenodd"
-                d="M22 12c0-5.523-4.477-10-10-10S2 6.477 2 12c0 4.991 3.657 9.128 8.438 9.878v-6.987h-2.54V12h2.54V9.797c0-2.506 1.492-3.89 3.777-3.89 1.094 0 2.238.195 2.238.195v2.46h-1.26c-1.243 0-1.63.771-1.63 1.562V12h2.773l-.443 2.89h-2.33v6.988C18.343 21.128 22 16.991 22 12z"
-                clipRule="evenodd"
-              />
-            </svg>
-            <span className="font-medium">Facebook</span>
-          </a>
-
-          <a
-            href="https://www.instagram.com/f3tornadoalley/"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-2 rounded-full bg-gradient-to-r from-purple-600 to-pink-600 px-6 py-3 text-white transition-all hover:from-purple-700 hover:to-pink-700 hover:scale-105"
-            aria-label="Visit our Instagram page"
-          >
-            <svg
-              className="h-5 w-5"
-              fill="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path
-                fillRule="evenodd"
-                d="M12.315 2c2.43 0 2.784.013 3.808.06 1.064.049 1.791.218 2.427.465a4.902 4.902 0 011.772 1.153 4.902 4.902 0 011.153 1.772c.247.636.416 1.363.465 2.427.048 1.067.06 1.407.06 4.123v.08c0 2.643-.012 2.987-.06 4.043-.049 1.064-.218 1.791-.465 2.427a4.902 4.902 0 01-1.153 1.772 4.902 4.902 0 01-1.772 1.153c-.636.247-1.363.416-2.427.465-1.067.048-1.407.06-4.123.06h-.08c-2.643 0-2.987-.012-4.043-.06-1.064-.049-1.791-.218-2.427-.465a4.902 4.902 0 01-1.772-1.153 4.902 4.902 0 01-1.153-1.772c-.247-.636-.416-1.363-.465-2.427-.047-1.024-.06-1.379-.06-3.808v-.63c0-2.43.013-2.784.06-3.808.049-1.064.218-1.791.465-2.427a4.902 4.902 0 011.153-1.772A4.902 4.902 0 015.45 2.525c.636-.247 1.363-.416 2.427-.465C8.901 2.013 9.256 2 11.685 2h.63zm-.081 1.802h-.468c-2.456 0-2.784.011-3.807.058-.975.045-1.504.207-1.857.344-.467.182-.8.398-1.15.748-.35.35-.566.683-.748 1.15-.137.353-.3.882-.344 1.857-.047 1.023-.058 1.351-.058 3.807v.468c0 2.456.011 2.784.058 3.807.045.975.207 1.504.344 1.857.182.466.399.8.748 1.15.35.35.683.566 1.15.748.353.137.882.3 1.857.344 1.054.048 1.37.058 4.041.058h.08c2.597 0 2.917-.01 3.96-.058.976-.045 1.505-.207 1.858-.344.466-.182.8-.398 1.15-.748.35-.35.566-.683.748-1.15.137-.353.3-.882.344-1.857.048-1.055.058-1.37.058-4.041v-.08c0-2.597-.01-2.917-.058-3.96-.045-.976-.207-1.505-.344-1.858a3.097 3.097 0 00-.748-1.15 3.098 3.098 0 00-1.15-.748c-.353-.137-.882-.3-1.857-.344-1.023-.047-1.351-.058-3.807-.058zM12 6.865a5.135 5.135 0 110 10.27 5.135 5.135 0 010-10.27zm0 1.802a3.333 3.333 0 100 6.666 3.333 3.333 0 000-6.666zm5.338-3.205a1.2 1.2 0 110 2.4 1.2 1.2 0 010-2.4z"
-                clipRule="evenodd"
-              />
-            </svg>
-            <span className="font-medium">Instagram</span>
-          </a>
-
-          <a
-            href="https://x.com/f3tornadoalley"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-2 rounded-full bg-black px-6 py-3 text-white transition-all hover:bg-gray-900 hover:scale-105"
-            aria-label="Visit our X (Twitter) page"
-          >
-            <svg
-              className="h-5 w-5"
-              fill="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
-            </svg>
-            <span className="font-medium">X</span>
-          </a>
-
-          <a
-            href="https://www.tiktok.com/@f3tornadoalley"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-2 rounded-full bg-black px-6 py-3 text-white transition-all hover:bg-gray-900 hover:scale-105"
-            aria-label="Visit our TikTok page"
-          >
-            <svg
-              className="h-5 w-5"
-              fill="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path d="M19.59 6.69a4.83 4.83 0 0 1-3.77-4.25V2h-3.45v13.67a2.89 2.89 0 0 1-5.2 1.74 2.89 2.89 0 0 1 2.31-4.64 2.93 2.93 0 0 1 .88.13V9.4a6.84 6.84 0 0 0-1-.05A6.33 6.33 0 0 0 5 20.1a6.34 6.34 0 0 0 10.86-4.43v-7a8.16 8.16 0 0 0 4.77 1.52v-3.4a4.85 4.85 0 0 1-1-.1z" />
-            </svg>
-            <span className="font-medium">TikTok</span>
-          </a>
-        </div>
-      </main>
-    </div>
+      </div>
     </>
   );
 }


### PR DESCRIPTION
## Summary
This PR modernizes the Tornado Alley homepage with a contemporary full-screen hero design that maximizes visual impact and implements F3 Nation's official branding.

### Visual Design Updates
- **Full-screen hero image**: Upgraded from 256px square to full viewport (100vw × 100vh) for maximum visual impact
- **F3 branding**: Implemented F3 Nation's official black (#000000) as the primary background color
- **Enhanced readability**: Added gradient overlay (from-black/60 via-black/40 to-black) over hero image
- **Responsive typography**: Heading now scales from text-6xl (mobile) to text-9xl (xl screens)
- **Visual depth**: Applied drop-shadow-2xl to heading for better contrast

### UI Component Improvements
- **Uniform button sizing**: All social media buttons standardized to 160px width × 48px height
- **Glassmorphism effects**: Added backdrop-blur-sm to all buttons for modern glass aesthetic
- **Enhanced styling**: Updated X and TikTok buttons with semi-transparent glass design (bg-white/10 with border)
- **Better shadows**: Upgraded all button shadows to shadow-xl for contemporary depth
- **Improved alignment**: Added justify-center to ensure perfect centering in fixed-width buttons

### Layout Architecture
- Converted from centered container to full-screen hero section
- Implemented absolute positioning for content overlay
- Maintained responsive gap spacing (gap-4 on mobile → gap-6 on larger screens)

## Preview
The new design creates a dramatic, modern first impression with the Ground Zero image spanning the entire viewport, overlaid with bold typography and sleek glassmorphic social buttons.

## Test Plan
- [x] Verify full-screen hero image displays correctly across all breakpoints
- [x] Confirm all social buttons are uniform size (160px × 48px)
- [x] Test glassmorphism effects on buttons
- [x] Validate gradient overlay provides sufficient text contrast
- [x] Check responsive typography scaling from mobile to desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)