### PR TITLE
Fix landing page full viewport layout and Cloudflare preview URLs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,9 @@ jobs:
         with:
           script: |
             const branchName = '${{ github.head_ref }}';
-            const previewUrl = `https://${branchName}.tornado-alley.pages.dev`;
+            // Cloudflare Pages converts slashes to dashes in branch names for preview URLs
+            const sanitizedBranch = branchName.replace(/\//g, '-');
+            const previewUrl = `https://${sanitizedBranch}.tornado-alley.pages.dev`;
 
             github.rest.issues.createComment({
               issue_number: context.issue.number,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -22,9 +22,9 @@ export default function Home() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
-      <div className="relative w-full bg-white">
-        {/* Hero Image Section - 65% of viewport */}
-        <div className="relative w-full h-[65vh]">
+      <div className="relative w-full min-h-[calc(100vh-64px)] bg-white flex flex-col">
+        {/* Hero Image Section - fills available space minus principles section */}
+        <div className="relative w-full flex-1 min-h-[50vh]">
           <Image
             src="https://pub-c59a7d8d850842288d7852af88d4ee66.r2.dev/images/2025_12_31_ground_zero.jpg"
             alt="Tornado Alley Ground Zero"
@@ -138,8 +138,8 @@ export default function Home() {
           </div>
         </div>
 
-        {/* 5 Core Principles Section - 25% of viewport */}
-        <div className="bg-white py-3 px-4">
+        {/* 5 Core Principles Section */}
+        <div className="bg-white py-6 px-4 flex-shrink-0">
           <div className="max-w-7xl mx-auto">
             <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4 md:gap-6">
               {/* Principle 1: Free of Charge */}


### PR DESCRIPTION
## Summary
This PR fixes two issues:

### 1. Landing Page Full Viewport Layout
The main landing page wasn't utilizing full screen real estate properly.

**Changes:**
- Container now uses `min-h-[calc(100vh-64px)]` to account for navigation height (64px)
- Uses flexbox layout with `flex-col` for proper section distribution
- Hero section uses `flex-1` to expand and fill available space
- Added `min-h-[50vh]` to hero to ensure minimum height on smaller content
- Principles section uses `flex-shrink-0` to maintain its size
- Increased principles section padding from `py-3` to `py-6` for better visual balance

### 2. Cloudflare Preview URL Generation
Preview URLs were malformed for branches with slashes (e.g., `feature/branch-name`).

**Before:** `https://feature/branch-name.tornado-alley.pages.dev` (invalid URL)
**After:** `https://feature-branch-name.tornado-alley.pages.dev` (valid URL)

**Changes:**
- Added slash-to-dash conversion in the GitHub Actions workflow
- Cloudflare Pages automatically converts slashes to dashes, so this matches their behavior

## Testing
- [ ] Landing page fills full viewport on desktop
- [ ] Landing page looks correct on mobile devices
- [ ] Preview URL in PR comment is correctly formatted