### PR TITLE
Alphabetize Boomtown locations

### DIFF
--- a/app/locations/page.tsx
+++ b/app/locations/page.tsx
@@ -13,14 +13,14 @@ export default function LocationsPage() {
     },
     {
       name: 'Boomtown',
-      description: 'OKC, Norman, Yukon, and Mustang area workout locations',
+      description: 'Mustang, Norman, OKC, and Yukon area workout locations',
       statsUrl: 'https://pax-vault.f3nation.com/stats/region/50857',
       regionInfoUrl: null,
       cities: [
-        { name: 'Oklahoma City', path: '/locations/okc' },
+        { name: 'Mustang', path: '/locations/mustang' },
         { name: 'Norman', path: '/locations/norman' },
-        { name: 'Yukon', path: '/locations/yukon' },
-        { name: 'Mustang', path: '/locations/mustang' }
+        { name: 'Oklahoma City', path: '/locations/okc' },
+        { name: 'Yukon', path: '/locations/yukon' }
       ]
     }
   ];


### PR DESCRIPTION
Alphabetizes cities in the Boomtown region: Mustang, Norman, OKC, Yukon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)